### PR TITLE
feat: 게시글 조회시 전달 데이터 추가

### DIFF
--- a/migrations/20220219140604-create-board.js
+++ b/migrations/20220219140604-create-board.js
@@ -8,14 +8,10 @@ module.exports = {
         primaryKey: true,
         type: Sequelize.INTEGER,
       },
-      userId: {
+      content: {
         type: Sequelize.STRING,
-  
       },
       img: {
-        type: Sequelize.STRING,
-      },
-      content: {
         type: Sequelize.STRING,
       },
       createdAt: {

--- a/migrations/20220220084042-create-user.js
+++ b/migrations/20220220084042-create-user.js
@@ -2,23 +2,15 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable("Users", {
-      id: {
-        allowNull: false,
-        primaryKey: true,
-        autoIncrement: true,
-
-        type: Sequelize.INTEGER,
-      },
       userId: {
         allowNull: false,
-        type: Sequelize.STRING,
-      },
-      nickname: {
-        allowNull: false,
+        primaryKey: true,
         type: Sequelize.STRING,
       },
       password: {
-        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      nickname: {
         type: Sequelize.STRING,
       },
       createdAt: {

--- a/migrations/20220220162204-create-like.js
+++ b/migrations/20220220162204-create-like.js
@@ -2,24 +2,14 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable("Likes", {
-      id: {
+      likeId: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
         type: Sequelize.INTEGER,
       },
-      userId: {
-        allowNull: false,
-        type: Sequelize.STRING,
-
-      },
-      postId: {
-        type: Sequelize.INTEGER,
-        allowNull: false,
-      
-      },
       check: {
-        type: Sequelize.BOOLEAN,
+        type: Sequelize.STRING,
       },
       createdAt: {
         allowNull: false,

--- a/migrations/20220223094055-add-Board-userId-col.js
+++ b/migrations/20220223094055-add-Board-userId-col.js
@@ -1,0 +1,36 @@
+"use strict";
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.addColumn(
+        "Boards",
+        "userId",
+        {
+          type: Sequelize.DataTypes.STRING,
+          reference: {
+            model: {
+              tableName: "Users",
+              key: "userId",
+            },
+          },
+        },
+        { transaction }
+      );
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.removeColumn("Boards", "userId", { transaction });
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+};

--- a/migrations/20220223094307-Like-userId-postId-col.js
+++ b/migrations/20220223094307-Like-userId-postId-col.js
@@ -1,0 +1,52 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.addColumn(
+        "Likes",
+        "userId",
+        {
+          type: Sequelize.DataTypes.STRING,
+          reference: {
+            model: {
+              tableName: "Users",
+              key: "userId",
+            },
+          },
+        },
+        { transaction }
+      );
+      await queryInterface.addColumn(
+        "Likes",
+        "postId",
+        {
+          type: Sequelize.DataTypes.INTEGER,
+          reference: {
+            model: {
+              tableName: "Boards",
+              key: "boardId",
+            },
+          },
+        },
+        { transaction }
+      );
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.removeColumn("Likes", "userId", { transaction });
+      await queryInterface.removeColumn("Likes", "postId", { transaction });
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+};

--- a/models/board.js
+++ b/models/board.js
@@ -4,31 +4,35 @@ module.exports = (sequelize, DataTypes) => {
   class Board extends Model {
     /**
      * Helper method for defining associations.
-     * This method is not a part of Sequelize lifecycle.
+     * Thins method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+     this.belongsTo(models.User, {
+       foreignKey: "userId",
+       targetKey: "userId",
+     });
+     this.hasMany(models.Like, { foreignKey: "postId", sourceKey: "postId" });
     }
   }
   Board.init(
     {
       postId: {
-        primaryKey: true,
         type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
       },
       userId: DataTypes.STRING,
-      img: DataTypes.STRING,
       content: DataTypes.STRING,
+      img: DataTypes.STRING,
     },
     {
       sequelize,
       modelName: "Board",
-      charset: "utf8", // 한국어 설정
-      collate: "utf8_general_ci", // 한국어 설정
+      timestamps: true,
+      charset: "utf8mb4",
+      collate: "utf8_generak_Ci",
     }
   );
-
-  
   return Board;
 };

--- a/models/like.js
+++ b/models/like.js
@@ -8,21 +8,32 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+       this.belongsTo(models.Board, {
+         foreignKey: "postId",
+         targetKey: "postId",
+       });
+       this.belongsTo(models.User, {
+         foreignKey: "userId",
+         targetKey: "userId",
+       });
     }
   }
   Like.init(
     {
-      userId: DataTypes.STRING,
-      postId: DataTypes.NUMBER,
+      likeId: {
+        primaryKey: true,
+        autoIncrement: true,
+        type: DataTypes.INTEGER,
+      },
       check: DataTypes.BOOLEAN,
     },
     {
       sequelize,
       modelName: "Like",
+      timestamps: true,
+      charset: "utf8mb4",
+      collate: "utf8_generak_Ci",
     }
   );
-
-
   return Like;
 };

--- a/models/user.js
+++ b/models/user.js
@@ -8,22 +8,31 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+          this.hasMany(models.Board, {
+            foreignKey: "userId",
+            sourceKey: "userId",
+          });
+          this.hasMany(models.Like, {
+            foreignKey: "userId",
+            sourceKey: "userId",
+          });
     }
   }
   User.init(
     {
-      id: {
+      userId: {
         primaryKey: true,
-        type: DataTypes.INTEGER,
+        type: DataTypes.STRING,
       },
-      userId: DataTypes.STRING,
-      nickname: DataTypes.STRING,
       password: DataTypes.STRING,
+      nickname: DataTypes.STRING,
     },
     {
       sequelize,
       modelName: "User",
+      timestamps: true,
+      charset: "utf8mb4",
+      collate: "utf8_generak_Ci",
     }
   );
 

--- a/routes/board.js
+++ b/routes/board.js
@@ -2,17 +2,40 @@ const express = require("express");
 const authMiddleware = require("../middlewares/auth-middleware");
 
 const { Op } = require("sequelize");
-const { Board, Like ,User} = require("../models/index");
+const { Board, Like, User } = require("../models/index");
 
 const router = express.Router();
 
 // 전체 게시글 목록 조회 API
 router.get("/", async (req, res) => {
   const posts = await Board.findAll({
-    attributes: ["postId", "userId"],
+    include: [
+      {
+        model: User,
+        required: false,
+        attributes: ["userId", "nickname"],
+      },
+      {
+        model: Like,
+        required: false,
+        attributes: ["userId", "postId"],
+      },
+    ],
   });
-  console.log(posts);
-  res.json({ posts });
+  const posts_obj = posts.map((ele) => {
+    const obj = {};
+
+    obj["post_id"] = ele["postId"];
+    obj["userId"] = ele["userId"];
+    obj["post_content"] = ele["content"];
+    obj["post_img"] = ele["img"];
+    obj["nickname"] = ele["User"].nickname;
+    obj["post_like"] = ele["Likes"].length;
+    obj["createdAt"] = ele["createdAt"];
+    obj["upload_date"] = ele["updatedAt"];
+    return obj;
+  });
+  res.json({ posts: posts_obj });
 });
 
 // 게시글 상세 조회 API
@@ -23,9 +46,34 @@ router.get("/:postId", async (req, res) => {
       .status(400)
       .json({ msg: false, errorMessage: "요청이 올바르지 않습니다." });
   }
-  const post = await Board.findOne({ where: { postId } });
+  const post = await Board.findOne({
+    where: { postId },
+    include: [
+      {
+        model: User,
+        required: false,
+        attributes: ["userId", "nickname"],
+      },
+      {
+        model: Like,
+        required: false,
+        attributes: ["userId", "postId"].count,
+      },
+    ],
+  });
 
-  res.json({ post });
+      const post_obj = {};
+
+      post_obj["post_id"] = post["postId"];
+      post_obj["userId"] = post["userId"];
+      post_obj["post_content"] = post["content"];
+      post_obj["post_img"] = post["img"];
+      post_obj["nickname"] = post["User"].nickname;
+      post_obj["post_like"] = post["Likes"].length;
+      post_obj["createdAt"] = post["createdAt"];
+      post_obj["upload_date"] = post["updatedAt"];
+
+  res.json({ post: post_obj });
 });
 
 // // 게시글 추가 API


### PR DESCRIPTION
mysql의 테이블을 Sequelize associate 맺고 조인해서 원하는 데이터를 추출 할 수 있게 db:migration을 추가했다.

게시판 목록 조회, 상세 조회에서 전달되는 데이터를 api 규칙에 맞게 수정했다.